### PR TITLE
move PaginationMarks to armoapi-go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.vscode*
+go.work
+go.work.*

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/armosec/opa-utils
 go 1.18
 
 require (
-	github.com/armosec/armoapi-go v0.0.73
+	github.com/armosec/armoapi-go v0.0.96
 	github.com/armosec/k8s-interface v0.0.78
 	github.com/armosec/rbac-utils v0.0.14
 	github.com/armosec/utils-go v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/armosec/armoapi-go v0.0.73 h1:LMf+eCkkf+W9NVvOzHKFgVUEpBMvh27M7//UQP3aiO8=
-github.com/armosec/armoapi-go v0.0.73/go.mod h1:/9SQAgtLbYkfFneRRm/zkIn3zz+4Y2xv6N3vtFcyF8s=
+github.com/armosec/armoapi-go v0.0.96 h1:8rOflchOs+dH2tXAxkxe6gGJqTHUVly6p6hcu2TzIiA=
+github.com/armosec/armoapi-go v0.0.96/go.mod h1:vpKd2UroTmzXKE1dSNQ6y2zRF13auJEmy9X2XBoFZYc=
 github.com/armosec/k8s-interface v0.0.78 h1:zqIzbFQqSxVMjcDsB4+lgGNgkHVqDZ369/WTGGdLKCE=
 github.com/armosec/k8s-interface v0.0.78/go.mod h1:8NX4xWXh8mwW7QyZdZea1czNdM2azCK9BbUNmiZYXW0=
 github.com/armosec/rbac-utils v0.0.14 h1:CKYKcgqJEXWF2Hen/B1pVGtS3nDAG1wp9dDv6oNtq90=

--- a/reporthandling/v2/datastructures.go
+++ b/reporthandling/v2/datastructures.go
@@ -3,17 +3,13 @@ package v2
 import (
 	"time"
 
+	armoapi "github.com/armosec/armoapi-go/apis"
 	"github.com/armosec/opa-utils/reporthandling"
 	"github.com/armosec/opa-utils/reporthandling/results/v1/reportsummary"
 	"github.com/armosec/opa-utils/reporthandling/results/v1/resourcesresults"
 
 	"k8s.io/apimachinery/pkg/version"
 )
-
-type PaginationMarks struct {
-	ReportNumber int  `json:"chunkNumber"` // serial number of report, used in pagination
-	IsLastReport bool `json:"isLastChunk"` //specify this is the last report, used in pagination
-}
 
 // PostureReport posture scanning report structure
 type PostureReport struct {
@@ -23,7 +19,7 @@ type PostureReport struct {
 	ClusterCloudProvider string                            `json:"clusterCloudProvider"` // Deprecated
 	ReportID             string                            `json:"reportGUID"`
 	JobID                string                            `json:"jobID"`
-	PaginationInfo       PaginationMarks                   `json:"paginationInfo"`
+	PaginationInfo       armoapi.PaginationMarks           `json:"paginationInfo"`
 	ClusterAPIServerInfo *version.Info                     `json:"clusterAPIServerInfo"`
 	ReportGenerationTime time.Time                         `json:"generationTime"`
 	SummaryDetails       reportsummary.SummaryDetails      `json:"summaryDetails,omitempty"`


### PR DESCRIPTION
move PaginationMarks to armoapi-go so it can be reused by container scan reports