### PR TITLE
docs: add OpenAPI annotations to httpserver objects

### DIFF
--- a/httpserver/apis/v1/apis.go
+++ b/httpserver/apis/v1/apis.go
@@ -1,5 +1,8 @@
 package v1
 
+// A kind of a Notification Policy
+//
+// swagger:enum NotificationPolicyKind
 type NotificationPolicyKind string
 
 // Supported NotificationKinds
@@ -9,13 +12,22 @@ const (
 	KindRule      NotificationPolicyKind = "Rule"
 )
 
+// Type of a Scan Response
+//
+// swagger:enum ScanResponseType
 type ScanResponseType string
 
 const (
-	IDScanResponseType        ScanResponseType = "id"        // DEPRECATED - will return busy/notBusy instead
-	ErrorScanResponseType     ScanResponseType = "error"     // error accrued, returning error message
-	ResultsV1ScanResponseType ScanResponseType = "v1results" // returning v1 results object
-	BusyScanResponseType      ScanResponseType = "busy"      // Server is busy with previous request
-	NotBusyScanResponseType   ScanResponseType = "notBusy"   // Server is not busy with previous request
-	ReadyScanResponseType     ScanResponseType = "ready"     // Server successfully completed request
+	// Deprecated: will return busy / notBusy instead
+	IDScanResponseType        ScanResponseType = "id"
+	// ErrorScanResponseType indicates a response that reports an error
+	ErrorScanResponseType     ScanResponseType = "error"
+	// ResultsV1ScanResponseType indicates a response that carries a v1 Results object as payload
+	ResultsV1ScanResponseType ScanResponseType = "v1results"
+	// BusyScanResponseType indicates that a server is busy with a previous request
+	BusyScanResponseType      ScanResponseType = "busy"
+	// NotBusyScanResponseType indicates that a server is not busy with a previous request
+	NotBusyScanResponseType   ScanResponseType = "notBusy"
+	// ReadyScanResponseType indicates that a server has successfully completed a request
+	ReadyScanResponseType     ScanResponseType = "ready"
 )

--- a/httpserver/meta/v1/datastructure.go
+++ b/httpserver/meta/v1/datastructure.go
@@ -2,26 +2,93 @@ package v1
 
 import v1 "github.com/armosec/opa-utils/httpserver/apis/v1"
 
+// A request to trigger a Kubescape scan
 type PostScanRequest struct {
-	Format             string                    `json:"format,omitempty"`             // Format results (table, json, junit ...) - default json
-	Account            string                    `json:"account,omitempty"`            // account ID
-	Logger             string                    `json:"-"`                            // logger level - debug/info/error - default is debug
-	FailThreshold      float32                   `json:"failThreshold,omitempty"`      // Failure score threshold
-	ExcludedNamespaces []string                  `json:"excludedNamespaces,omitempty"` // used for host scanner namespace
-	IncludeNamespaces  []string                  `json:"includeNamespaces,omitempty"`  // DEPRECATED?
-	TargetNames        []string                  `json:"targetNames,omitempty"`        // default is all
-	TargetType         v1.NotificationPolicyKind `json:"targetType,omitempty"`         // framework/control - default is framework
-	Submit             *bool                     `json:"submit,omitempty"`             // Submit results to Armo BE - default will
-	HostScanner        *bool                     `json:"hostScanner,omitempty"`        // Deploy ARMO K8s host scanner to collect data from certain controls
-	KeepLocal          *bool                     `json:"keepLocal,omitempty"`          // Do not submit results
-	UseCachedArtifacts *bool                     `json:"useCachedArtifacts,omitempty"` // Use the cached artifacts instead of downloading
+	// Logger level (debug / info / error, default is "debug")
+	Logger string `json:"-"`
+	// Format of the results.
+	//
+	// Same as `kubescape scan --format`.
+	//
+	// Example: json
+	Format string `json:"format,omitempty"`
+	// A Kubescape account ID to use for scanning.
+	//
+	// Same as `kubescape scan --account`.
+	//
+	// Example: d13791eb-19b1-4222-867b-9a7c1799cfac
+	// swagger:strfmt uuid4
+	//
+	Account string `json:"account,omitempty"`
+	// Threshold for a failing score.
+	//
+	// Scores higher than the provided value will be considered failing.
+	//
+	// Example: 42
+	FailThreshold float32 `json:"failThreshold,omitempty"`
+	// Namespaces to exclude.
+	//
+	// Same as `kubescape scan --excluded-namespaces`.
+	//
+	// Example: ["armo-system", "kube-system"]
+	ExcludedNamespaces []string `json:"excludedNamespaces,omitempty"`
+	// Namespaces to include.
+	//
+	// Same as `kubescape scan --include-namespaces`.
+	//
+	// Example: ["litmus-tests", "known-bad"]
+	IncludeNamespaces []string `json:"includeNamespaces,omitempty"`
+	// Name of the scan targets.
+	//
+	// For example, if you select `targetType: "framework"`, you can trigger a scan using the NSA and MITRE ATT&CK Framework by passing `targetNames: ["nsa", "mitre"].
+	//
+	// Example: ["nsa", "mitre"]
+	// Default: ["all"]
+	TargetNames []string `json:"targetNames,omitempty"`
+	// Type of the target. "framework" or "control".
+	//
+	// Example: "control"
+	// Default: "framework"
+	TargetType v1.NotificationPolicyKind `json:"targetType,omitempty"`
+	// Submit results to Kubescape Cloud.
+	//
+	// Same as `kubescape scan --submit`.
+	Submit *bool `json:"submit,omitempty"`
+	// Deploy the Kubescape Kubernetes Host Scanner
+	//
+	// Deploys the Armo K8s Host Scanner DeamonSet in the scanned cluster to collect data from certain controls.
+	//
+	// Example: true
+	HostScanner *bool `json:"hostScanner,omitempty"`
+	// Do not submit results to Kubescape Cloud.
+	//
+	// Same as `kubescape scan --keep-local`
+	//
+	// Example: true
+	KeepLocal *bool `json:"keepLocal,omitempty"`
+	// Use the cached artifacts instead of downloading (offline support)
+	//
+	// Example: false
+	UseCachedArtifacts *bool `json:"useCachedArtifacts,omitempty"`
 	// UseExceptions      string      // Load file with exceptions configuration
 	// ControlsInputs     string      // Load file with inputs for controls
 	// VerboseMode        bool        // Display all of the input resources and not only failed resources
 }
 
+// A Scan Response object
 type Response struct {
-	ID       string              `json:"id"`
-	Type     v1.ScanResponseType `json:"type"`
-	Response interface{}         `json:"response,omitempty"`
+	// ID of the scan
+	//
+	// Example: d13791eb-19b1-4222-867b-9a7c1799cfac
+	//
+	// swagger:strfmt uuid4
+	ID string `json:"id"`
+	// Type of this response
+	//
+	// Example: busy
+	Type v1.ScanResponseType `json:"type"`
+	// The actual Response payload
+	//
+	// Example: d13791eb-19b1-4222-867b-9a7c1799cfac
+	Response interface{} `json:"response,omitempty"`
 }


### PR DESCRIPTION
# What this PR does?

This PR adds OpenAPI annotations compatible with `go-swagger`, so downstream clients can generate OpenAPI specs from exported objects declared for use in HTTP APIs.

Affected objects:
- v1.Response
- v1.PostScanRequest
- v1.ScanResponseType
- v1.NotificationPolicyKind